### PR TITLE
Adds tests, controller and finds accuWeather to be inaccurate.

### DIFF
--- a/app/controllers/api/v1/location_controller.rb
+++ b/app/controllers/api/v1/location_controller.rb
@@ -1,0 +1,24 @@
+class Api::V1::LocationController < ApplicationController
+  def show
+    ip_address = params["ip"]
+    request = Faraday.new("http://dataservice.accuweather.com/locations/v1/cities/ipaddress?q=#{ip_address}") do |f|
+      f.adapter Faraday.default_adapter
+      f.params[:apikey] = ENV["accuweather_api_key"]
+    end
+    response = request.get
+    results = JSON.parse(response.body, symbolize_name: true)
+
+    render json: {"Country": {
+      "ID": results["Country"]["ID"],
+      "LocalizedName": results["Country"]["LocalizedName"]
+    },
+      "latitude": results["GeoPosition"]["Latitude"],
+      "longitude": results["GeoPosition"]["Longitude"],
+      "IsDaylightSaving": results["TimeZone"]["IsDaylightSaving"],
+      "processingCode":
+      ("(" + results["Country"]["LocalizedName"] + " - " +
+      results["AdministrativeArea"]["LocalizedName"] + " - " +
+      results["LocalizedName"] + ")" )
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      get '/location', to: 'location#show'
+    end
+  end
 end

--- a/spec/requests/api/v1/acuu_weather_spec.rb
+++ b/spec/requests/api/v1/acuu_weather_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+RSpec.describe 'IP Address API' do
+  it 'can get the location based on an IP address' do
+    get '/api/v1/location?q=73.229.237.237'
+    results = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+    expect(results[:Country][:ID]).to eq("US")
+    expect(results[:Country][:LocalizedName]).to eq("United States")
+    expect(results[:IsDaylightSaving]).to eq(true)
+    expect(results[:processingCode]).to eq("(United States - Colorado - Denver)")
+    expect(results[:latitude]).to eq(39.6796)
+    expect(results[:longitude]).to eq(-104.9626)
+  end
+end


### PR DESCRIPTION
I believe something is amiss with AccuWeather's IP location finder, for the following reasons:
< my IP address is 73.229.237.237 and AccuWeather states that I am in Lansdale, PA. 
< I verified my IP address in a couple different places 
< a friend currently in Denver got Philadelphia
< The api documentation testing area gets the same results as my solution